### PR TITLE
feat: Add limited time functionality to gacha pools

### DIFF
--- a/core/database/migrations/009_add_gacha_pool_limited_time.py
+++ b/core/database/migrations/009_add_gacha_pool_limited_time.py
@@ -1,0 +1,10 @@
+def up(cursor):
+    # 添加限时开放字段
+    cursor.execute("""
+        ALTER TABLE gacha_pools ADD COLUMN is_limited_time INTEGER DEFAULT 0
+    """)
+    cursor.execute("""
+        ALTER TABLE gacha_pools ADD COLUMN open_until TEXT
+    """)
+
+

--- a/core/domain/models.py
+++ b/core/domain/models.py
@@ -110,6 +110,9 @@ class GachaPool:
     description: Optional[str] = None
     cost_coins: int = 0
     cost_premium_currency: int = 0
+    # 限时开放控制
+    is_limited_time: int = 0  # 0/1 存储于数据库，前端按布尔使用
+    open_until: Optional[str] = None  # 以文本存储的ISO时间（SQLite）
     # 这个字段让模型更丰富，可以在服务层组装，存放该池的所有奖品
     items: List[GachaPoolItem] = field(default_factory=list)
 

--- a/core/repositories/sqlite_gacha_repo.py
+++ b/core/repositories/sqlite_gacha_repo.py
@@ -106,13 +106,15 @@ class SqliteGachaRepository(AbstractGachaRepository):
         with self._get_connection() as conn:
             cursor = conn.cursor()
             cursor.execute("""
-                INSERT INTO gacha_pools (name, description, cost_coins, cost_premium_currency)
-                VALUES (:name, :description, :cost_coins, :cost_premium_currency)
+                INSERT INTO gacha_pools (name, description, cost_coins, cost_premium_currency, is_limited_time, open_until)
+                VALUES (:name, :description, :cost_coins, :cost_premium_currency, :is_limited_time, :open_until)
             """, {
                 "name": data.get("name"),
                 "description": data.get("description"),
                 "cost_coins": data.get("cost_coins", 0),
-                "cost_premium_currency": data.get("cost_premium_currency", 0)
+                "cost_premium_currency": data.get("cost_premium_currency", 0),
+                "is_limited_time": 1 if data.get("is_limited_time") in (True, "1", 1, "on") else 0,
+                "open_until": data.get("open_until")
             })
             conn.commit()
 
@@ -126,14 +128,18 @@ class SqliteGachaRepository(AbstractGachaRepository):
                     name = :name,
                     description = :description,
                     cost_coins = :cost_coins,
-                    cost_premium_currency = :cost_premium_currency
+                    cost_premium_currency = :cost_premium_currency,
+                    is_limited_time = :is_limited_time,
+                    open_until = :open_until
                 WHERE gacha_pool_id = :gacha_pool_id
             """, {
                 "gacha_pool_id": pool_id,
                 "name": data.get("name"),
                 "description": data.get("description"),
                 "cost_coins": data.get("cost_coins", 0),
-                "cost_premium_currency": data.get("cost_premium_currency", 0)
+                "cost_premium_currency": data.get("cost_premium_currency", 0),
+                "is_limited_time": 1 if data.get("is_limited_time") in (True, "1", 1, "on") else 0,
+                "open_until": data.get("open_until")
             })
             conn.commit()
 
@@ -157,13 +163,15 @@ class SqliteGachaRepository(AbstractGachaRepository):
             
             # 创建新卡池，名称加上"(副本)"
             cursor.execute("""
-                INSERT INTO gacha_pools (name, description, cost_coins, cost_premium_currency)
-                VALUES (?, ?, ?, ?)
+                INSERT INTO gacha_pools (name, description, cost_coins, cost_premium_currency, is_limited_time, open_until)
+                VALUES (?, ?, ?, ?, ?, ?)
             """, (
                 f"{original_pool['name']} (副本)",
                 original_pool['description'],
                 original_pool['cost_coins'],
-                original_pool['cost_premium_currency']
+                original_pool['cost_premium_currency'],
+                original_pool['is_limited_time'] if 'is_limited_time' in original_pool.keys() else 0,
+                original_pool['open_until'] if 'open_until' in original_pool.keys() else None
             ))
             
             # 获取新卡池ID

--- a/manager/server.py
+++ b/manager/server.py
@@ -295,6 +295,8 @@ async def add_gacha_pool():
         "description": data.get("description"),
         "cost_coins": amount if currency_type == "coins" else 0,
         "cost_premium_currency": amount if currency_type == "premium" else 0,
+        "is_limited_time": data.get("is_limited_time"),
+        "open_until": data.get("open_until")
     }
     item_template_service.add_pool_template(payload)
     await flash("奖池添加成功！", "success")
@@ -314,6 +316,8 @@ async def edit_gacha_pool(pool_id):
         "description": data.get("description"),
         "cost_coins": amount if currency_type == "coins" else 0,
         "cost_premium_currency": amount if currency_type == "premium" else 0,
+        "is_limited_time": data.get("is_limited_time"),
+        "open_until": data.get("open_until")
     }
     item_template_service.update_pool_template(pool_id, payload)
     await flash(f"奖池ID {pool_id} 更新成功！", "success")

--- a/manager/templates/gacha.html
+++ b/manager/templates/gacha.html
@@ -17,6 +17,12 @@
                 <p class="card-text">{{ pool.description or '无描述' }}</p>
                 
                 <p>
+                    {% if pool.is_limited_time %}
+                        <span class="badge bg-danger me-2">限时开放</span>
+                        {% if pool.open_until %}
+                            <span class="badge bg-outline-secondary text-dark">至 {{ pool.open_until }}</span>
+                        {% endif %}
+                    {% endif %}
                     {% if pool.cost_premium_currency and pool.cost_premium_currency > 0 %}
                         <span class="badge bg-warning text-dark">花费：高级货币 {{ pool.cost_premium_currency }}</span>
                     {% else %}
@@ -63,6 +69,15 @@
                 <div class="modal-body">
                     <div class="mb-3"><label>名称</label><input type="text" name="name" class="form-control" required></div>
                     <div class="mb-3"><label>描述</label><textarea name="description" class="form-control" rows="2"></textarea></div>
+                    <div class="form-check form-switch mb-2">
+                        <input class="form-check-input" type="checkbox" id="isLimitedTime" name="is_limited_time">
+                        <label class="form-check-label" for="isLimitedTime">限时开放</label>
+                    </div>
+                    <div class="mb-3">
+                        <label>开放截止时间</label>
+                        <input type="datetime-local" name="open_until" class="form-control">
+                        <div class="form-text">开启限时后，设置开放到什么时候（本地时间）。</div>
+                    </div>
                     <div class="mb-3">
                         <label>消耗货币</label>
                         <select name="currency_type" class="form-select">
@@ -97,6 +112,8 @@ document.addEventListener('DOMContentLoaded', function () {
         form.reset();
         if (form.elements['currency_type']) form.elements['currency_type'].value = 'coins';
         if (form.elements['cost_amount']) form.elements['cost_amount'].value = 0;
+        if (form.elements['is_limited_time']) form.elements['is_limited_time'].checked = false;
+        if (form.elements['open_until']) form.elements['open_until'].value = '';
     });
 
     document.querySelectorAll('.edit-btn').forEach(button => {
@@ -112,6 +129,10 @@ document.addEventListener('DOMContentLoaded', function () {
             const isPremium = (data.cost_premium_currency && data.cost_premium_currency > 0);
             if (form.elements['currency_type']) form.elements['currency_type'].value = isPremium ? 'premium' : 'coins';
             if (form.elements['cost_amount']) form.elements['cost_amount'].value = isPremium ? (data.cost_premium_currency || 0) : (data.cost_coins || 0);
+
+            // 限时开放
+            if (form.elements['is_limited_time']) form.elements['is_limited_time'].checked = !!data.is_limited_time;
+            if (form.elements['open_until']) form.elements['open_until'].value = data.open_until ? data.open_until.replace(' ', 'T') : '';
         });
     });
 });


### PR DESCRIPTION
- Introduced `is_limited_time` and `open_until` fields in the `GachaPool` model to manage time-limited gacha pools.
- Updated the `SqliteGachaRepository` to handle these new fields during pool creation and updates.
- Enhanced the `add_gacha_pool` and `edit_gacha_pool` functions in `server.py` to accept and process the new fields.
- Modified the `gacha.html` template to display limited time indicators and input options for setting the open until date.

## Summary by Sourcery

Introduce time-limited gacha pool support by adding new model fields, database migrations, repository persistence, server handling, and UI elements for toggling and displaying deadlines.

New Features:
- Add is_limited_time and open_until fields to GachaPool model and database schema for time-limited pools
- Expose a toggle and datetime input in the pool management modal to set limited-time availability
- Show limited-time badges and deadline information on gacha pool cards

Enhancements:
- Update repository methods to persist and copy limited-time attributes
- Extend server handlers to accept and process the new limited-time fields
- Adapt form reset and edit scripts to initialize and display the limited-time fields correctly