### PR TITLE
Feat implement inline editing for gacha pool item weights

### DIFF
--- a/manager/server.py
+++ b/manager/server.py
@@ -7,7 +7,7 @@ import io
 
 from quart import (
     Quart, render_template, request, redirect, url_for, session, flash,
-    Blueprint, current_app
+    Blueprint, current_app, jsonify
 )
 from astrbot.api import logger
 
@@ -667,6 +667,33 @@ async def delete_pool_item(item_id):
     item_template_service.delete_pool_item(item_id)
     await flash(f"奖池物品ID {item_id} 已删除！", "warning")
     return redirect(url_for("admin_bp.manage_gacha_pool_details", pool_id=pool_id))
+
+
+@admin_bp.route("/gacha/pool/update_weight/<int:item_id>", methods=["POST"])
+@login_required
+async def update_pool_item_weight(item_id):
+    """快速更新奖池物品权重"""
+    try:
+        data = await request.get_json()
+        weight = data.get("weight")
+        
+        if not weight or not isinstance(weight, (int, float)) or weight < 1:
+            return jsonify({"success": False, "message": "权重必须是大于0的数字"}), 400
+        
+        item_template_service = current_app.config["ITEM_TEMPLATE_SERVICE"]
+        
+        # 获取当前物品信息
+        pool_items = item_template_service.get_pool_items(item_id)
+        if not pool_items:
+            return jsonify({"success": False, "message": "物品不存在"}), 404
+        
+        # 更新权重
+        item_template_service.update_pool_item(item_id, {"weight": int(weight)})
+        
+        return jsonify({"success": True, "message": "权重更新成功"})
+        
+    except Exception as e:
+        return jsonify({"success": False, "message": f"更新失败: {str(e)}"}), 500
 
 
 # --- 用户管理 ---

--- a/manager/server.py
+++ b/manager/server.py
@@ -682,12 +682,7 @@ async def update_pool_item_weight(item_id):
         
         item_template_service = current_app.config["ITEM_TEMPLATE_SERVICE"]
         
-        # 获取当前物品信息
-        pool_items = item_template_service.get_pool_items(item_id)
-        if not pool_items:
-            return jsonify({"success": False, "message": "物品不存在"}), 404
-        
-        # 更新权重
+        # 直接更新权重，update_pool_item方法会处理验证
         item_template_service.update_pool_item(item_id, {"weight": int(weight)})
         
         return jsonify({"success": True, "message": "权重更新成功"})

--- a/manager/server.py
+++ b/manager/server.py
@@ -677,6 +677,9 @@ async def update_pool_item_weight(item_id):
         data = await request.get_json()
         weight = data.get("weight")
         
+        # 调试信息
+        logger.info(f"更新权重请求 - item_id: {item_id}, data: {data}, weight: {weight}")
+        
         if not weight or not isinstance(weight, (int, float)) or weight < 1:
             return jsonify({"success": False, "message": "权重必须是大于0的数字"}), 400
         
@@ -685,9 +688,11 @@ async def update_pool_item_weight(item_id):
         # 直接更新权重，update_pool_item方法会处理验证
         item_template_service.update_pool_item(item_id, {"weight": int(weight)})
         
+        logger.info(f"权重更新成功 - item_id: {item_id}, weight: {weight}")
         return jsonify({"success": True, "message": "权重更新成功"})
         
     except Exception as e:
+        logger.error(f"权重更新失败 - item_id: {item_id}, error: {str(e)}")
         return jsonify({"success": False, "message": f"更新失败: {str(e)}"}), 500
 
 

--- a/manager/server.py
+++ b/manager/server.py
@@ -676,21 +676,17 @@ async def update_pool_item_weight(item_id):
     try:
         data = await request.get_json()
         weight = data.get("weight")
-        
-        # 调试信息
-        logger.info(f"更新权重请求 - item_id: {item_id}, data: {data}, weight: {weight}")
-        
+
         if not weight or not isinstance(weight, (int, float)) or weight < 1:
             return jsonify({"success": False, "message": "权重必须是大于0的数字"}), 400
-        
+
         item_template_service = current_app.config["ITEM_TEMPLATE_SERVICE"]
-        
+
         # 直接更新权重，update_pool_item方法会处理验证
         item_template_service.update_pool_item(item_id, {"weight": int(weight)})
-        
-        logger.info(f"权重更新成功 - item_id: {item_id}, weight: {weight}")
+
         return jsonify({"success": True, "message": "权重更新成功"})
-        
+
     except Exception as e:
         logger.error(f"权重更新失败 - item_id: {item_id}, error: {str(e)}")
         return jsonify({"success": False, "message": f"更新失败: {str(e)}"}), 500

--- a/manager/templates/gacha_pool_details.html
+++ b/manager/templates/gacha_pool_details.html
@@ -253,9 +253,6 @@ document.addEventListener('DOMContentLoaded', function () {
         const itemId = input.dataset.itemId;
         const weight = parseInt(input.value);
         
-        // 调试信息
-        console.log('保存权重 - itemId:', itemId, 'weight:', weight);
-        
         if (!itemId) {
             showToast('错误：无法获取物品ID', 'error');
             return;

--- a/manager/templates/gacha_pool_details.html
+++ b/manager/templates/gacha_pool_details.html
@@ -253,6 +253,14 @@ document.addEventListener('DOMContentLoaded', function () {
         const itemId = input.dataset.itemId;
         const weight = parseInt(input.value);
         
+        // 调试信息
+        console.log('保存权重 - itemId:', itemId, 'weight:', weight);
+        
+        if (!itemId) {
+            showToast('错误：无法获取物品ID', 'error');
+            return;
+        }
+        
         if (weight < 1 || weight > 1000) {
             showToast('权重必须在1-1000之间', 'error');
             input.focus();

--- a/manager/templates/gacha_pool_details.html
+++ b/manager/templates/gacha_pool_details.html
@@ -38,7 +38,30 @@
                         </td>
                         <td><span class="badge bg-secondary">{{ item.item_type }}</span></td>
                         <td>{{ item.quantity }}</td>
-                        <td>{{ item.weight }}</td>
+                        <td>
+                            <div class="d-flex align-items-center">
+                                <input type="number" 
+                                       class="form-control form-control-sm weight-input" 
+                                       value="{{ item.weight }}" 
+                                       data-item-id="{{ item.gacha_pool_item_id }}"
+                                       data-original-value="{{ item.weight }}"
+                                       min="1" 
+                                       max="1000"
+                                       style="width: 80px;">
+                                <div class="ms-2">
+                                    <button class="btn btn-sm btn-success save-weight-btn d-none" 
+                                            data-item-id="{{ item.gacha_pool_item_id }}"
+                                            title="保存">
+                                        <i class="fas fa-check"></i>
+                                    </button>
+                                    <button class="btn btn-sm btn-secondary cancel-weight-btn d-none" 
+                                            data-item-id="{{ item.gacha_pool_item_id }}"
+                                            title="取消">
+                                        <i class="fas fa-times"></i>
+                                    </button>
+                                </div>
+                            </div>
+                        </td>
                         <td class="text-end">
                             <button class="btn btn-sm btn-info edit-btn"
                                     data-bs-toggle="modal"
@@ -145,6 +168,160 @@ document.addEventListener('DOMContentLoaded', function () {
                 form.elements['quantity'].value = data.quantity;
                 form.elements['weight'].value = data.weight;
             });
+        });
+    }
+
+    // 权重内联编辑功能
+    const weightInputs = document.querySelectorAll('.weight-input');
+    const saveButtons = document.querySelectorAll('.save-weight-btn');
+    const cancelButtons = document.querySelectorAll('.cancel-weight-btn');
+
+    weightInputs.forEach(input => {
+        let originalValue = input.value;
+        
+        input.addEventListener('focus', function() {
+            originalValue = this.value;
+            this.classList.add('border-primary');
+            showActionButtons(this);
+        });
+
+        input.addEventListener('blur', function() {
+            if (this.value === originalValue) {
+                hideActionButtons(this);
+                this.classList.remove('border-primary');
+            }
+        });
+
+        input.addEventListener('input', function() {
+            if (this.value !== originalValue) {
+                showActionButtons(this);
+            } else {
+                hideActionButtons(this);
+            }
+        });
+
+        input.addEventListener('keydown', function(e) {
+            if (e.key === 'Enter') {
+                e.preventDefault();
+                saveWeight(this);
+            } else if (e.key === 'Escape') {
+                e.preventDefault();
+                cancelEdit(this);
+            }
+        });
+    });
+
+    saveButtons.forEach(button => {
+        button.addEventListener('click', function() {
+            const input = this.closest('td').querySelector('.weight-input');
+            saveWeight(input);
+        });
+    });
+
+    cancelButtons.forEach(button => {
+        button.addEventListener('click', function() {
+            const input = this.closest('td').querySelector('.weight-input');
+            cancelEdit(input);
+        });
+    });
+
+    function showActionButtons(input) {
+        const container = input.closest('td');
+        const saveBtn = container.querySelector('.save-weight-btn');
+        const cancelBtn = container.querySelector('.cancel-weight-btn');
+        
+        saveBtn.classList.remove('d-none');
+        cancelBtn.classList.remove('d-none');
+    }
+
+    function hideActionButtons(input) {
+        const container = input.closest('td');
+        const saveBtn = container.querySelector('.save-weight-btn');
+        const cancelBtn = container.querySelector('.cancel-weight-btn');
+        
+        saveBtn.classList.add('d-none');
+        cancelBtn.classList.add('d-none');
+    }
+
+    function cancelEdit(input) {
+        input.value = input.dataset.originalValue;
+        input.classList.remove('border-primary');
+        hideActionButtons(input);
+    }
+
+    async function saveWeight(input) {
+        const itemId = input.dataset.itemId;
+        const weight = parseInt(input.value);
+        
+        if (weight < 1 || weight > 1000) {
+            showToast('权重必须在1-1000之间', 'error');
+            input.focus();
+            return;
+        }
+
+        // 显示保存状态
+        const saveBtn = input.closest('td').querySelector('.save-weight-btn');
+        const originalIcon = saveBtn.innerHTML;
+        saveBtn.innerHTML = '<i class="fas fa-spinner fa-spin"></i>';
+        saveBtn.disabled = true;
+
+        try {
+            const response = await fetch(`/admin/gacha/pool/update_weight/${itemId}`, {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                },
+                body: JSON.stringify({ weight: weight })
+            });
+
+            const result = await response.json();
+
+            if (result.success) {
+                input.dataset.originalValue = weight.toString();
+                input.classList.remove('border-primary');
+                hideActionButtons(input);
+                showToast('权重更新成功', 'success');
+            } else {
+                showToast(result.message || '更新失败', 'error');
+                input.focus();
+            }
+        } catch (error) {
+            showToast('网络错误，请重试', 'error');
+            input.focus();
+        } finally {
+            saveBtn.innerHTML = originalIcon;
+            saveBtn.disabled = false;
+        }
+    }
+
+    function showToast(message, type) {
+        // 创建toast元素
+        const toast = document.createElement('div');
+        toast.className = `toast align-items-center text-white bg-${type === 'success' ? 'success' : 'danger'} border-0`;
+        toast.setAttribute('role', 'alert');
+        toast.innerHTML = `
+            <div class="d-flex">
+                <div class="toast-body">${message}</div>
+                <button type="button" class="btn-close btn-close-white me-2 m-auto" data-bs-dismiss="toast"></button>
+            </div>
+        `;
+
+        // 添加到页面
+        let toastContainer = document.querySelector('.toast-container');
+        if (!toastContainer) {
+            toastContainer = document.createElement('div');
+            toastContainer.className = 'toast-container position-fixed top-0 end-0 p-3';
+            document.body.appendChild(toastContainer);
+        }
+        toastContainer.appendChild(toast);
+
+        // 显示toast
+        const bsToast = new bootstrap.Toast(toast);
+        bsToast.show();
+
+        // 自动移除
+        toast.addEventListener('hidden.bs.toast', () => {
+            toast.remove();
         });
     }
 });


### PR DESCRIPTION
refactor: Simplify weight update logic in update_pool_item_weight function
- Removed unnecessary retrieval of pool item information before updating weight.
- Streamlined the weight update process by directly calling the update method, which now handles validation internally.

## Summary by Sourcery

Implement inline editing for gacha pool item weights with a new UI and backend endpoint for updating weights.

New Features:
- Add inline weight input fields with save and cancel buttons and toast notifications in the gacha pool details page
- Introduce a POST route update_pool_item_weight to handle AJAX weight updates

Enhancements:
- Simplify server-side weight update logic by directly calling update_pool_item with internal validation