### PR TITLE
feat: add configurable daily reset time for fishing zones

### DIFF
--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -53,6 +53,12 @@
     "hint": "每次钓鱼后的冷却时间，单位为秒",
     "default": 180
   },
+  "daily_reset_hour": {
+    "description": "每日刷新时间点",
+    "type": "int",
+    "hint": "每日重置鱼塘配额、税收等的时间点（小时，0-23），默认为0表示0点刷新",
+    "default": 0
+  },
   "steal_cooldown_seconds": {
     "description": "偷鱼的冷却时间",
     "type": "int",

--- a/core/utils.py
+++ b/core/utils.py
@@ -11,6 +11,31 @@ def get_now() -> datetime:
 def get_today() -> date:
     return get_now().date()
 
+def get_last_reset_time(reset_hour: int = 0) -> datetime:
+    """
+    获取最近一次刷新时间点
+    
+    Args:
+        reset_hour: 每日刷新的小时数（0-23），默认为0表示0点刷新
+    
+    Returns:
+        最近一次刷新的时间点（datetime对象）
+    
+    Example:
+        如果 reset_hour=6，当前时间是今天8点，返回今天6点
+        如果 reset_hour=6，当前时间是今天5点，返回昨天6点
+    """
+    now = get_now()
+    # 创建今天的刷新时间点
+    today_reset = now.replace(hour=reset_hour, minute=0, second=0, microsecond=0)
+    
+    # 如果当前时间已经过了今天的刷新时间点，返回今天的刷新时间点
+    if now >= today_reset:
+        return today_reset
+    else:
+        # 否则返回昨天的刷新时间点
+        return today_reset - timedelta(days=1)
+
 def get_fish_template(new_fish_list, coins_chance):
     sorted_fish_list = sorted(new_fish_list, key=lambda x: x.base_value, reverse=True)
     random_index = random.randint(0, len(sorted_fish_list) - 1)


### PR DESCRIPTION
- Add daily_reset_hour config option (0-23) to _conf_schema.json
- Implement get_last_reset_time() utility function in core/utils.py
- Update fishing service to use custom reset time instead of fixed midnight
- Replace date-based reset logic with time-based reset detection
- Support flexible daily refresh timing for quotas, taxes, and zone checks
- Default remains 0 (midnight) for backward compatibility

This allows administrators to set any hour (0-23) as the daily reset time instead of being fixed at midnight, providing more flexibility for different time zones and server management preferences.

## Summary by Sourcery

Enable administrators to set a custom daily reset hour for fishing zones by adding a configuration option, time-based reset utility, and updating the fishing service to trigger resets at the specified hour.

New Features:
- Add configurable daily reset hour for fishing service via 'daily_reset_hour' setting
- Introduce get_last_reset_time utility to compute last reset timestamp based on custom hour

Enhancements:
- Switch fishing service from date-based to time-based daily reset detection
- Update configuration schema to include 'daily_reset_hour' with default midnight