### PR TITLE
feat: add daily limit configuration for the Wheel of Fate game

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@
 [![AGPL-3.0 License](https://img.shields.io/badge/License-AGPL--3.0-blue.svg)](https://opensource.org/licenses/AGPL-3.0)
 [![Python](https://img.shields.io/badge/Python-3.8+-green.svg)](https://python.org)
 [![AstrBot](https://img.shields.io/badge/AstrBot-Plugin-orange.svg)](https://github.com/astrbot/astrbot)
-[![Version](https://img.shields.io/badge/Version-2.2.0-brightgreen.svg)](https://github.com/xxlemon-io/astrbot_plugin_fishing/releases/tag/v2.2.0)
+[![Version](https://img.shields.io/badge/Version-2.2.1-brightgreen.svg)](https://github.com/xxlemon-io/astrbot_plugin_fishing/releases/tag/v2.2.1)
 [![Major Update](https://img.shields.io/badge/Major-Update-red.svg)](https://github.com/xxlemon-io/astrbot_plugin_fishing/releases/tag/v2.0.0)
 
 ## ✨ 功能特点
@@ -102,6 +102,12 @@
 如果您有功能建议或发现问题，欢迎在 [Issues](https://github.com/xxlemon-io/astrbot_plugin_fishing/issues) 中提出！
  
 ## 📦 更新记录
+
+#### v2.2.1 (命运轮盘平衡调整)
+
+- **⚖️ 命运轮盘平衡调整**：每日次数限制从5次调整为3次，重新设计为高风险高回报模型
+- **🔧 命运轮盘可配置**：每日次数限制现在可通过配置文件调整，默认值为3次
+- **🎯 庄家优势保证**：整体House Edge约67%
 
 #### v2.2.0 (新游戏玩法与功能优化)
 
@@ -552,10 +558,14 @@
 
 #### 🎰 命运之轮
 
-- **轮盘游戏**：高风险高回报的轮盘游戏
-- **多轮挑战**：支持多轮游戏，可以继续或放弃
-- **策略选择**：玩家需要在适当时机选择继续或放弃
-- **奖励递增**：每轮奖励递增，但风险也增加
+- **轮盘游戏**：高风险高回报的策略性轮盘游戏
+- **多轮挑战**：支持10层挑战，可以随时继续或放弃
+- **高风险定位**：起始成功率65%，符合轮盘游戏的刺激特性
+- **第1层诱惑**：第1层期望微盈利（0.75%），吸引玩家尝试
+- **风险递增**：第2层开始期望亏损，成功率从60%递减至20%
+- **高倍率奖励**：通关倍率高达数百倍，刺激冒险玩家挑战
+- **每日限制**：每天最多可玩3次（可配置），平衡游戏经济
+- **庄家优势**：整体House Edge约67%，确保长期回收货币
 
 #### 📦 批量稀有度出售
 

--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -77,6 +77,12 @@
     "hint": "每次电鱼后的冷却时间，单位为秒",
     "default": 7200
   },
+  "wheel_of_fate_daily_limit": {
+    "description": "命运轮盘每日次数限制",
+    "type": "int",
+    "hint": "每个用户每天可以玩命运轮盘的最大次数",
+    "default": 3
+  },
   "user_initial_coins": {
     "description": "用户初始金币",
     "type": "int",

--- a/core/services/game_mechanics_service.py
+++ b/core/services/game_mechanics_service.py
@@ -61,16 +61,16 @@ class GameMechanicsService:
         "cooldown_seconds": 60,
         "timeout_seconds": 60,
         "levels": [
-            { "level": 1, "success_rate": 0.75, "multiplier": 1.15 },
-            { "level": 2, "success_rate": 0.70, "multiplier": 1.2 },
-            { "level": 3, "success_rate": 0.65, "multiplier": 1.3 },
-            { "level": 4, "success_rate": 0.60, "multiplier": 1.4 },
-            { "level": 5, "success_rate": 0.55, "multiplier": 1.5 },
-            { "level": 6, "success_rate": 0.50, "multiplier": 1.8 },
-            { "level": 7, "success_rate": 0.45, "multiplier": 2.3 },
-            { "level": 8, "success_rate": 0.40, "multiplier": 3.0 },
-            { "level": 9, "success_rate": 0.35, "multiplier": 4.0 },
-            { "level": 10, "success_rate": 0.30, "multiplier": 2.6 }
+            { "level": 1, "success_rate": 0.65, "multiplier": 1.55 },  # 高风险起点，期望微盈利0.75%
+            { "level": 2, "success_rate": 0.60, "multiplier": 1.45 },  # 开始亏损，防止稳赚
+            { "level": 3, "success_rate": 0.55, "multiplier": 1.55 },  # 风险递增
+            { "level": 4, "success_rate": 0.50, "multiplier": 1.70 },  # 中等风险
+            { "level": 5, "success_rate": 0.45, "multiplier": 1.90 },  # 较高风险
+            { "level": 6, "success_rate": 0.40, "multiplier": 2.15 },  # 高风险
+            { "level": 7, "success_rate": 0.35, "multiplier": 2.50 },  # 极高风险
+            { "level": 8, "success_rate": 0.30, "multiplier": 3.00 },  # 冒险者区域
+            { "level": 9, "success_rate": 0.25, "multiplier": 3.70 },  # 追梦者区域
+            { "level": 10, "success_rate": 0.20, "multiplier": 4.80 }  # 通关巨奖
         ]
     }
     # ------------------------------------
@@ -485,7 +485,7 @@ class GameMechanicsService:
             return {"success": False, "message": f"[CQ:at,qq={user_id}] 你已经在游戏中了，请回复【继续】或【放弃】。"}
 
         # --- [新功能] 每日次数限制逻辑 ---
-        WHEEL_OF_FATE_DAILY_LIMIT = 5
+        wheel_of_fate_daily_limit = self.config.get("wheel_of_fate_daily_limit", 3)
         today_str = get_today().strftime('%Y-%m-%d')
 
         # 如果记录的日期不是今天，重置计数器
@@ -494,8 +494,8 @@ class GameMechanicsService:
             user.last_wof_date = today_str
 
         # 检查次数是否已达上限
-        if user.wof_plays_today >= WHEEL_OF_FATE_DAILY_LIMIT:
-            return {"success": False, "message": f"今天的运气已经用光啦！你今天已经玩了 {user.wof_plays_today}/{WHEEL_OF_FATE_DAILY_LIMIT} 次命运之轮，请明天再来吧。"}
+        if user.wof_plays_today >= wheel_of_fate_daily_limit:
+            return {"success": False, "message": f"今天的运气已经用光啦！你今天已经玩了 {user.wof_plays_today}/{wheel_of_fate_daily_limit} 次命运之轮，请明天再来吧。"}
         # --- 限制逻辑结束 ---
 
         config = self.WHEEL_OF_FATE_CONFIG

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,5 +1,5 @@
 ﻿name: Fishing Another!
-version: 2.2.0
+version: 2.2.1
 author: "xxlemon"
 description: "全新架构的钓鱼插件！重构擦弹、抽卡、商店系统，支持多商店类型和复杂商品机制，新增水族箱系统提供安全存储空间，附带完整后台管理界面（支持原版fishing存档继续游玩）"
 repo: https://github.com/xxlemon-io/astrbot_plugin_fishing


### PR DESCRIPTION
- Introduced a new configuration option for the daily play limit of the Wheel of Fate, defaulting to 3 plays per user.
- Updated game mechanics to enforce the daily limit and adjusted success rates and multipliers for a balanced gameplay experience.
- Incremented version to 2.2.1 and updated README to reflect changes and new features.

## Summary by Sourcery

Introduce a configurable daily play limit for the Wheel of Fate, enforce it in the game logic, rebalance the level success rates and multipliers, and update documentation and version metadata accordingly

New Features:
- Add configurable daily play limit for the Wheel of Fate, defaulting to 3 plays per user

Enhancements:
- Rebalance success rates and multipliers across all Wheel of Fate levels to increase risk and maintain house edge
- Enforce the daily play limit in the game mechanics instead of using a hard-coded value

Documentation:
- Update README to version 2.2.1 with details on the new configurable limit and balance adjustments

Chores:
- Bump plugin version to 2.2.1 in metadata and release badge