### PR TITLE
修复会开启多个税收线程的bug

### DIFF
--- a/main.py
+++ b/main.py
@@ -857,6 +857,7 @@ class FishingPlugin(Star):
         """插件被卸载/停用时调用"""
         logger.info("钓鱼插件正在终止...")
         self.fishing_service.stop_auto_fishing_task()
+        self.fishing_service.stop_daily_tax_task()  # 终止独立的税收线程
         self.achievement_service.stop_achievement_check_task()
         self.exchange_service.stop_daily_price_update_task() # 终止交易所后台任务
         if self.web_admin_task:


### PR DESCRIPTION
之前在插件被卸载时忘了终止税收线程，导致出现多个税收线程。

## Summary by Sourcery

Bug Fixes:
- Stop the daily tax task on plugin unload to prevent spawning multiple tax threads