### PR TITLE
fix：At list中需要先排除机器人本身的id，适配dingtalk的At逻辑

### DIFF
--- a/handlers/inventory_handlers.py
+++ b/handlers/inventory_handlers.py
@@ -137,8 +137,10 @@ async def peek_pond(plugin: "FishingPlugin", event: AstrMessageEvent):
         # 检查消息中是否有At对象
         for comp in message_obj.message:
             if isinstance(comp, At):
-                target_user_id = str(comp.qq)
-                break
+                # 排除机器人本身的id
+                if comp.qq != message_obj.self_id:
+                    target_user_id = str(comp.qq)
+                    break
 
     # 如果没有@，尝试从消息文本中解析
     if target_user_id is None:

--- a/handlers/social_handlers.py
+++ b/handlers/social_handlers.py
@@ -99,8 +99,9 @@ async def steal_fish(plugin: "FishingPlugin", event: AstrMessageEvent):
     if hasattr(message_obj, "message"):
         for comp in message_obj.message:
             if isinstance(comp, At):
-                target_id = comp.qq
-                break
+                if comp.qq != message_obj.self_id:
+                    target_id = str(comp.qq)
+                    break
 
     if target_id is None:
         parts = event.message_str.strip().split()
@@ -137,8 +138,10 @@ async def electric_fish(plugin: "FishingPlugin", event: AstrMessageEvent):
     if hasattr(message_obj, "message"):
         for comp in message_obj.message:
             if isinstance(comp, At):
-                target_id = comp.qq
-                break
+                # 排除机器人本身的id
+                if comp.qq != message_obj.self_id:
+                    target_id = str(comp.qq)
+                    break
 
     if target_id is None:
         parts = event.message_str.strip().split()

--- a/utils.py
+++ b/utils.py
@@ -368,8 +368,10 @@ def parse_target_user_id(event, args: list, arg_index: int = 1) -> Tuple[Optiona
         # 检查消息中是否有At对象
         for comp in message_obj.message:
             if isinstance(comp, At):
-                target_id = comp.qq
-                break
+                # 排除机器人本身的id
+                if comp.qq != message_obj.self_id:
+                    target_id = str(comp.qq)
+                    break
     
     # 如果从@中获取到了用户ID，直接返回
     if target_id is not None:


### PR DESCRIPTION
astrbot添加了dingtalk的At逻辑处理，在fishing中处理一下atlist，
```python
            # 处理所有被 @ 的用户（包括机器人自己，因 at_users 已包含）
            if message.at_users:
                for user in message.at_users:
                    if user.dingtalk_id:
                        abm.message.append(At(qq=user.dingtalk_id))
/
``` 
https://github.com/AstrBotDevs/AstrBot/pull/3186#event-20599122979

Dingtalk已完成测试
```
 [11:45:10] [Core] [INFO] [core.event_bus:52]: [default] [dingtalk_RajerBot(dingtalk)] UserA/$:LWCP_v1:$qcAoAZL+NKabJFxfOSjwgsiVJJ/FL6tO: [At:$:LWCP_v1:$BkVYa/kxHnHf+z63AxHrarMjD4v3dFMW] [At:$:LWCP_v1:$hEFyVbhD6SbSY7JNG2jfNKCHyj8nBfNP] 偷鱼  
 [11:45:10] [Core] [INFO] [respond.stage:161]: Prepare to send - UserA/$:LWCP_v1:$qcAoAZL+NKabJFxfOSjwgsiVJJ/FL6tO: [引用消息] [At:$:LWCP_v1:$qcAoAZL+NKabJFxfOSjwgsiVJJ/FL6tO] 
✅ 成功从【UserB】的鱼塘里偷到了一条2★【无须鳕】！价值 54 金币  
```

## Summary by Sourcery

Exclude the bot's own ID when handling @ mentions to ensure correct target user selection for fishing and inventory commands under Dingtalk

Bug Fixes:
- Skip the robot itself when parsing @ mentions in steal_fish and electric_fish handlers
- Ignore the bot's own ID in peek_pond inventory handler when extracting target user
- Exclude the bot's self ID in parse_target_user_id utility for @ mention resolution