### PR TITLE
fix：修复插件名称显示问题

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,4 +1,5 @@
-﻿name: Fishing Another!
+﻿name: astrbot_plugin_fishing
+display_name: Fishing Another!
 version: 2.4.6
 author: "xxlemon"
 description: "全新架构钓鱼插件！更多交互，多商店系统、交易所、品质系统、水族箱和Web管理（支持原版fishing存档继续游玩）"


### PR DESCRIPTION
## 变更描述
插件仓库名称和插件名称为“astrbot_plugin_fishing”，但原yaml文件使用插件别名“Fishing Another!”当做插件名，导致控制面板和使用“plugin ls”指令时显示的是插件别名，会误导使用者对指令的使用以及对插件名的了解。
如图所示：
图1：
![Screenshot_2025-11-25-03-02-31-229_com tencent mobileqq-edit](https://github.com/user-attachments/assets/491ce52e-0d85-486a-88d3-b338f2668706)
图2：
<img width="1069" height="698" alt="IMG_20251125_030416" src="https://github.com/user-attachments/assets/e0b49049-aea9-41ad-a029-32322fecb8c9" />

通过在yaml新增astrbot框架自带的“display_name”设置插件别名，改正插件名称“name”，可以达到控制面板上正确显示插件名称的同时也展示出插件别名的效果[图3]，同时使用“plugin ls”指令也能正确显示插件名称[图4]。
图3：
![Screenshot_2025-11-25-03-01-04-156_org mozilla firefox-edit](https://github.com/user-attachments/assets/75a08146-47f0-45c4-bba6-22ddf0188607)
图4：
![Screenshot_2025-11-25-03-11-27-534_com tencent mobileqq-edit](https://github.com/user-attachments/assets/a671cb26-23e6-4cf1-a059-c45b9b44fde3)
图5：
<img width="1063" height="489" alt="IMG_20251125_031216" src="https://github.com/user-attachments/assets/8ab7db4f-8c66-4539-91eb-a5248dd379d2" />


<!-- 请简要描述本次 PR 的变更内容 -->

## 变更类型

<!-- 请勾选适用的类型 -->

- [ ✔️] 🐛 Bug修复
- [ ] ✨ 新功能
- [ ] 📝 文档更新
- [ ] 🎨 代码格式调整
- [ ] ♻️ 代码重构
- [ ] ⚡ 性能优化
- [ ] ✅ 测试相关
- [ ] 🔧 构建/工具相关
- [ ] 🔒 安全相关

## 测试说明

<!-- 请描述如何测试这些变更 -->

- [ ✔️] 已测试相关功能
- [✔️ ] 已检查代码格式
- [ ] 已更新相关文档（如适用）

## 检查清单

<!-- 提交 PR 前请确认以下事项 -->

- [✔️ ] 代码遵循项目规范
- [ ✔️] 已添加必要的注释和文档
- [ ✔️] 已通过所有测试（如有）
- [ ✔️] 提交信息清晰明确

## ⚠️ 重要提醒

**请确认您的 PR 目标分支是 `develop`，而不是 `main`！**

- ✅ 目标分支：`develop`
- ❌ 不要提交到：`main`

---

感谢您的贡献！🎣

## Summary by Sourcery

Bug Fixes:
- Fix plugin name in metadata so the framework and commands use the correct identifier while retaining the user-facing alias via display_name.